### PR TITLE
Add Laravel 12 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "type": "library",
     "require": {
         "php": "^7.3|^8.0",
-        "laravel/framework": "^5.8|^6.0|^7.0|^8.0|^8.1|^9.0|^10.0|^11.0",
+        "laravel/framework": "^5.8|^6.0|^7.0|^8.0|^8.1|^9.0|^10.0|^11.0|^12.0",
         "hidehalo/nanoid-php": "^1.1",
         "robinvdvleuten/ulid": "^5.0"
     },


### PR DESCRIPTION
NOTE: This is untested. I haven't had a chance to upgrade an application to 12.X yet, but this was one of the few packages which was showing as incompatible.